### PR TITLE
Fix duplicate _cq_id column when reading CQ-written Parquet files

### DIFF
--- a/client/discover.go
+++ b/client/discover.go
@@ -79,7 +79,20 @@ func (c *Client) discover(ctx context.Context) ([]DiscoveredTable, error) {
 			Columns:       columns,
 			IsIncremental: true,
 		}
-		schema.AddCqIDs(table)
+		// Only add CQ ID columns if they don't already exist in the Parquet schema.
+		// Parquet files written by other CQ source plugins already contain _cq_id
+		// and _cq_parent_id columns, so adding them again would cause a duplicate
+		// column validation error.
+		hasCqID := false
+		for _, col := range table.Columns {
+			if col.Name == "_cq_id" {
+				hasCqID = true
+				break
+			}
+		}
+		if !hasCqID {
+			schema.AddCqIDs(table)
+		}
 		tables[i].Table = table
 	}
 


### PR DESCRIPTION
## Summary

- Fix duplicate `_cq_id` column error when `cq-source-s3` reads Parquet files that were written by another CloudQuery source plugin (e.g., `ibcq-source-k8s` via `cq-destination-s3`)
- Check for existing `_cq_id` column before calling `schema.AddCqIDs(table)` in `client/discover.go`

Fixes #1

## Root Cause

In `client/discover.go` line 82, `schema.AddCqIDs(table)` is called unconditionally. Parquet files written by other CQ source plugins already contain `_cq_id` and `_cq_parent_id` metadata columns, so adding them again causes:

```
Error: failed to sync v3 source s3: failed to init source s3: rpc error: code = Internal
desc = failed to init plugin: failed to validate tables: found duplicate columns in plugin:
duplicate column _cq_id in table k8s_dk_local_k8s_apps_deployments
```

## Test plan

- [ ] Verify sync works with Parquet files written by another CQ source plugin (containing `_cq_id` columns)
- [ ] Verify sync still works with plain Parquet files (not written by CQ, no `_cq_id` columns)
- [ ] Verify `_cq_id` and `_cq_parent_id` columns are present in both cases